### PR TITLE
remove volume name from pvc so that a pv can be allocated dynamically

### DIFF
--- a/mysql/src/main/fabric8/zipkin-mysql-pvc.yml
+++ b/mysql/src/main/fabric8/zipkin-mysql-pvc.yml
@@ -8,4 +8,3 @@ spec:
   resources:
     requests:
       storage: 100Mi
-  volumeName: mysql-data


### PR DESCRIPTION
An explicit volume name in the pvc object makes an assumption that a persistent volume exists with that name. This pull request modifies the pvc object so that a pv with any name can be bound, as long as it meets the storage specifications.